### PR TITLE
add devext support Awake, OnDestroy

### DIFF
--- a/Assets/RatherGood/MMOKit/RGPanda/Scripts/PandaBrain.cs
+++ b/Assets/RatherGood/MMOKit/RGPanda/Scripts/PandaBrain.cs
@@ -55,6 +55,7 @@ namespace RatherGood.Panda
             Entity.onNotifyEnemySpottedByAlly += Entity_onNotifyEnemySpottedByAlly;
             Entity.onReceivedDamage += Entity_onReceivedDamage;
 
+            this.InvokeInstanceDevExtMethods("Awake");
         }
 
         public override void EntityOnDestroy()
@@ -63,6 +64,8 @@ namespace RatherGood.Panda
             Entity.onNotifyEnemySpotted -= Entity_onNotifyEnemySpotted;
             Entity.onNotifyEnemySpottedByAlly -= Entity_onNotifyEnemySpottedByAlly;
             Entity.onReceivedDamage -= Entity_onReceivedDamage;
+
+            this.InvokeInstanceDevExtMethods("OnDestroy");
         }
 
 


### PR DESCRIPTION
enables partials to tap into Awake, OnDestroy for example

`namespace RatherGood.Panda
{
	public partial class PandaBrain
	{
		[DevExtMethods("Awake")]
		protected void PandaBrain_SpawnManager__Awake()
		{
			Entity.onSetup += PandaBrain_SpawnManager__OnSetup;
		}

		[DevExtMethods("OnDestroy")]
		protected void PandaBrain_SpawnManager__OnDestroy()
		{
			Entity.onSetup -= PandaBrain_SpawnManager__OnSetup;
		}
        }
}
`